### PR TITLE
Implement timezone detection via ipapi

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ testing:
 Recuerda deshabilitarlo en producción.
 
 ## Limitaciones conocidas
-- La detección de zona horaria por IP aún es un **placeholder**, por lo que todos los jugadores se consideran en la misma zona horaria.
+- La detección de zona horaria ahora se realiza a través de `ipapi.co`. Si la consulta falla se usará la zona horaria por defecto del servidor.
 - La descarga de dependencias puede fallar en entornos sin acceso a Internet (por ejemplo, en este entorno de pruebas).
 
 ## Licencia

--- a/src/main/java/studio/joaosouza/sabbathMode/managers/SabbathManager.java
+++ b/src/main/java/studio/joaosouza/sabbathMode/managers/SabbathManager.java
@@ -4,6 +4,12 @@ import net.md_5.bungee.api.plugin.Plugin;
 import studio.joaosouza.sabbathMode.SabbathMode;
 import studio.joaosouza.sabbathMode.config.PluginConfig;
 
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+
 import java.time.DayOfWeek;
 import java.time.LocalTime;
 import java.time.ZoneId;
@@ -16,6 +22,9 @@ public class SabbathManager {
     private final PluginConfig config;
 
     private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm");
+    private static final HttpClient HTTP_CLIENT = HttpClient.newBuilder()
+            .connectTimeout(Duration.ofSeconds(5))
+            .build();
 
     public SabbathManager(Plugin plugin) {
         this.plugin = plugin;
@@ -23,16 +32,7 @@ public class SabbathManager {
     }
 
     public SabbathCheckResult isSabbath(String playerIp){
-        ZoneId playerZoneId = null;
-
-        try{
-            //ACÁ SE ENLAZA CON LA API DE GEOLOCALIZACIÓN PERO TODAVÍA NO LO HACEMOS xd
-
-            playerZoneId = ZoneId.of("America/Lima"); // PLACEHOLDER
-        } catch (Exception e) {
-            plugin.getLogger().warning("Error al intentar determinar la zona horaria de la ip: " + playerIp + " :" + e.getMessage());
-            playerZoneId = ZoneId.of("America/Lima"); // Fallback
-        }
+        ZoneId playerZoneId = determineZoneFromIp(playerIp);
 
         ZonedDateTime nowInPlayerZone = ZonedDateTime.now(playerZoneId);
 
@@ -102,6 +102,29 @@ public class SabbathManager {
         return new SabbathCheckResult(isSabbathActive, playerZoneId, formattedSabbathEndTime);
     }
 
+    private ZoneId determineZoneFromIp(String ip) {
+        try {
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create("https://ipapi.co/" + ip + "/timezone/"))
+                    .timeout(Duration.ofSeconds(5))
+                    .GET()
+                    .build();
+
+            HttpResponse<String> response = HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
+            if (response.statusCode() == 200) {
+                String body = response.body().trim();
+                if (!body.isEmpty()) {
+                    return ZoneId.of(body);
+                }
+            } else {
+                plugin.getLogger().warning("Fallo obteniendo zona para " + ip + ": HTTP " + response.statusCode());
+            }
+        } catch (Exception e) {
+            plugin.getLogger().warning("Error al obtener zona para " + ip + ": " + e.getMessage());
+        }
+        return ZoneId.systemDefault();
+    }
+
     // CHECK RESULT
     public static class SabbathCheckResult {
         private final boolean isSabbathActive;
@@ -110,7 +133,7 @@ public class SabbathManager {
 
         public SabbathCheckResult(boolean isSabbathActive, ZoneId zoneId, String saturdaySunsetTime) {
             this.isSabbathActive = isSabbathActive;
-            this.zoneId = ZoneId.systemDefault();
+            this.zoneId = zoneId;
             this.saturdaySunsetTime = saturdaySunsetTime;
         }
 


### PR DESCRIPTION
## Summary
- determine player timezone via ipapi.co instead of fixed placeholder
- store the detected zone ID in the result
- note in README that timezone detection uses ipapi.co

## Testing
- `mvn -q -DskipTests package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853c225fff483288f81a6f5e0dc0b1c