### PR TITLE
Add whitelist support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ SabbathMode es un plugin para BungeeCord que restringe el acceso al servidor dur
 - Bloquea las conexiones desde el **viernes a las 18:00** hasta el **sábado a las 18:00** (según la zona horaria del jugador).
 - Mensaje de denegación personalizable mediante `config.yml`.
 - Modo de pruebas para ajustar manualmente el rango de horario.
+- Whitelist de jugadores que pueden ingresar durante el Sabbath.
 
 ## Compilación
 1. Asegúrate de tener **Java 17** y **Maven** instalados.
@@ -18,7 +19,8 @@ SabbathMode es un plugin para BungeeCord que restringe el acceso al servidor dur
 ## Instalación y uso
 1. Copia `config.yml` en la carpeta de datos del plugin si no se genera automáticamente.
 2. Ajusta `messages.sabbath-denied` con el mensaje que verán los jugadores.
-3. Coloca el JAR generado en la carpeta `plugins` de tu servidor BungeeCord y reinícialo.
+3. Modifica `whitelist` para agregar jugadores exentos de la restricción.
+4. Coloca el JAR generado en la carpeta `plugins` de tu servidor BungeeCord y reinícialo.
 
 ### Activar modo de pruebas
 Si deseas probar horarios diferentes, edita la sección `testing` de `config.yml`:

--- a/src/main/java/studio/joaosouza/sabbathMode/config/PluginConfig.java
+++ b/src/main/java/studio/joaosouza/sabbathMode/config/PluginConfig.java
@@ -24,6 +24,8 @@ public class PluginConfig {
     private DayOfWeek testSabbathEndDay;
     private LocalTime testSabbathEndTime;
 
+    private java.util.Set<String> whitelistedPlayers;
+
 
     public PluginConfig(Plugin plugin, File configFile) {
         this.plugin = plugin;
@@ -35,6 +37,19 @@ public class PluginConfig {
             //CONFIGURACIÓN DESDE YAML
             config = ConfigurationProvider.getProvider(YamlConfiguration.class).load(configFile);
             sabbathDeniedMessage = config.getString("messages.sabbath-denied", "&cEl servidor está cerrado hoy.\n\n&79. Seis días trabajarás, y harás toda tu obra;\n&710. mas el séptimo día es reposo para Jehová tu Dios;\n&6Exodo 20:9-10\n\n&cAcceso restringido en tu zona horaria (&e{zone_id}&c).\n&cPuedes ingresar a partir del &eSábado &ca las &e{saturday_sunset_time} &c(hora local).");
+
+            // CARGAR LISTA DE WHITELIST
+            java.util.List<String> wl = config.getStringList("whitelist");
+            if (wl != null) {
+                whitelistedPlayers = new java.util.HashSet<>();
+                for (String p : wl) {
+                    if (p != null) {
+                        whitelistedPlayers.add(p.toLowerCase());
+                    }
+                }
+            } else {
+                whitelistedPlayers = java.util.Collections.emptySet();
+            }
 
             // CARGAR CONFIGURACIONES DE TESTING:
             testingEnabled = config.getBoolean("testing.enabled", false);
@@ -79,6 +94,14 @@ public class PluginConfig {
             changed = true;
         }
 
+        if (!config.contains("whitelist")) {
+            java.util.List<String> defaults = new java.util.ArrayList<>();
+            defaults.add("EjemploUsuario1");
+            defaults.add("EjemploUsuario2");
+            config.set("whitelist", defaults);
+            changed = true;
+        }
+
         if (changed) {
             try {
                 ConfigurationProvider.getProvider(YamlConfiguration.class).save(config, configFile);
@@ -111,5 +134,9 @@ public class PluginConfig {
 
     public LocalTime getTestSabbathEndTime() {
         return testSabbathEndTime;
+    }
+
+    public java.util.Set<String> getWhitelistedPlayers() {
+        return whitelistedPlayers;
     }
 }

--- a/src/main/java/studio/joaosouza/sabbathMode/listeners/ConnectionListener.java
+++ b/src/main/java/studio/joaosouza/sabbathMode/listeners/ConnectionListener.java
@@ -28,6 +28,11 @@ public class ConnectionListener implements Listener {
         String ipAddress = address.getAddress().getHostAddress();
         String playerName = event.getConnection().getName();
 
+        if (plugin.getPluginConfig().getWhitelistedPlayers().contains(playerName.toLowerCase())) {
+            plugin.getLogger().info("Conexión de " + playerName + " (IP: " + ipAddress + ") PERMITIDA por whitelist.");
+            return;
+        }
+
         SabbathManager.SabbathCheckResult checkResult = plugin.getSabbathManager().isSabbath(ipAddress);
 
         if (checkResult.isSabbathActive()) {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -20,4 +20,9 @@ testing:
   sabbath-end-day: SATURDAY
   sabbath-end-time: "18:00"
 
-# PRÓXIMO: WHITELIST de USUARIOS
+# Lista de jugadores que pueden conectarse durante el Sabbath.
+# Escribe sus nombres exactos (sin color ni formato).
+whitelist:
+  - EjemploUsuario1
+  - EjemploUsuario2
+


### PR DESCRIPTION
## Summary
- allow configuring a list of exempt players
- skip Sabbath check for whitelisted names
- document whitelist option in README

## Testing
- `mvn -q -e -DskipTests package` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853c4d92ff883288b2d3a2b1010ed7f