### PR TITLE
Add admin command with reload and config editing

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,20 @@ testing:
 ```
 Recuerda deshabilitarlo en producción.
 
+### Comandos
+El plugin incluye el comando `/sabbath` (permiso `sabbathmode.admin`) con varias opciones:
+
+```
+/sabbath reload                     # Recarga la configuración
+/sabbath whitelist add <jugador>    # Añade un jugador a la whitelist
+/sabbath whitelist remove <jugador> # Quita un jugador de la whitelist
+/sabbath message show               # Muestra el mensaje de denegación actual
+/sabbath message set <mensaje>      # Cambia el mensaje de denegación
+/sabbath testing on|off             # Activa o desactiva el modo de pruebas
+/sabbath testing start <DIA> <HH:mm> # Define inicio del Sabbath en pruebas
+/sabbath testing end <DIA> <HH:mm>   # Define fin del Sabbath en pruebas
+```
+
 ## Limitaciones conocidas
 - La detección de zona horaria ahora se realiza a través de `ipapi.co`. Si la consulta falla se usará la zona horaria por defecto del servidor.
 - La descarga de dependencias puede fallar en entornos sin acceso a Internet (por ejemplo, en este entorno de pruebas).

--- a/src/main/java/studio/joaosouza/sabbathMode/SabbathMode.java
+++ b/src/main/java/studio/joaosouza/sabbathMode/SabbathMode.java
@@ -5,6 +5,7 @@ import net.md_5.bungee.api.plugin.Plugin;
 import studio.joaosouza.sabbathMode.config.PluginConfig;
 import studio.joaosouza.sabbathMode.listeners.ConnectionListener;
 import studio.joaosouza.sabbathMode.managers.SabbathManager;
+import studio.joaosouza.sabbathMode.commands.SabbathCommand;
 
 import java.io.File;
 import java.io.InputStream;
@@ -52,6 +53,7 @@ public final class SabbathMode extends Plugin {
         ProxyServer.getInstance().getPluginManager().registerListener(this, new ConnectionListener(this));
 
         //4. REGISTRAR COMANDOS
+        ProxyServer.getInstance().getPluginManager().registerCommand(this, new SabbathCommand(this));
         getLogger().info("----------------------------------------");
         getLogger().info(" §aSabbathMode §f- §aHabilitado Correctamente.");
         getLogger().info("----------------------------------------");

--- a/src/main/java/studio/joaosouza/sabbathMode/commands/SabbathCommand.java
+++ b/src/main/java/studio/joaosouza/sabbathMode/commands/SabbathCommand.java
@@ -1,0 +1,128 @@
+package studio.joaosouza.sabbathMode.commands;
+
+import net.md_5.bungee.api.ChatColor;
+import net.md_5.bungee.api.CommandSender;
+import net.md_5.bungee.api.chat.TextComponent;
+import net.md_5.bungee.api.plugin.Command;
+import studio.joaosouza.sabbathMode.SabbathMode;
+import studio.joaosouza.sabbathMode.config.PluginConfig;
+
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+
+public class SabbathCommand extends Command {
+
+    private final SabbathMode plugin;
+    private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm");
+
+    public SabbathCommand(SabbathMode plugin) {
+        super("sabbath", "sabbathmode.admin", new String[]{});
+        this.plugin = plugin;
+    }
+
+    @Override
+    public void execute(CommandSender sender, String[] args) {
+        if (args.length == 0) {
+            sendHelp(sender);
+            return;
+        }
+
+        PluginConfig config = plugin.getPluginConfig();
+
+        switch (args[0].toLowerCase()) {
+            case "reload":
+                config.reloadConfig();
+                sender.sendMessage(new TextComponent(ChatColor.GREEN + "Configuración recargada."));
+                break;
+            case "whitelist":
+                handleWhitelist(sender, config, args);
+                break;
+            case "message":
+                handleMessage(sender, config, args);
+                break;
+            case "testing":
+                handleTesting(sender, config, args);
+                break;
+            default:
+                sendHelp(sender);
+                break;
+        }
+    }
+
+    private void handleWhitelist(CommandSender sender, PluginConfig config, String[] args) {
+        if (args.length < 3) {
+            sendHelp(sender);
+            return;
+        }
+        String player = args[2];
+        if (args[1].equalsIgnoreCase("add")) {
+            config.addWhitelistedPlayer(player);
+            sender.sendMessage(new TextComponent(ChatColor.GREEN + "Añadido a la whitelist: " + player));
+        } else if (args[1].equalsIgnoreCase("remove")) {
+            config.removeWhitelistedPlayer(player);
+            sender.sendMessage(new TextComponent(ChatColor.GREEN + "Eliminado de la whitelist: " + player));
+        } else {
+            sendHelp(sender);
+        }
+    }
+
+    private void handleMessage(CommandSender sender, PluginConfig config, String[] args) {
+        if (args.length < 2) {
+            sendHelp(sender);
+            return;
+        }
+        if (args[1].equalsIgnoreCase("show")) {
+            sender.sendMessage(new TextComponent(ChatColor.translateAlternateColorCodes('&', config.getSabbathDeniedMessage())));
+        } else if (args[1].equalsIgnoreCase("set")) {
+            if (args.length < 3) {
+                sendHelp(sender);
+                return;
+            }
+            String message = String.join(" ", Arrays.copyOfRange(args, 2, args.length));
+            config.setSabbathDeniedMessage(message);
+            sender.sendMessage(new TextComponent(ChatColor.GREEN + "Mensaje actualizado."));
+        } else {
+            sendHelp(sender);
+        }
+    }
+
+    private void handleTesting(CommandSender sender, PluginConfig config, String[] args) {
+        if (args.length < 2) {
+            sendHelp(sender);
+            return;
+        }
+        if (args[1].equalsIgnoreCase("on")) {
+            config.setTestingEnabled(true);
+            sender.sendMessage(new TextComponent(ChatColor.GREEN + "Modo de pruebas activado."));
+        } else if (args[1].equalsIgnoreCase("off")) {
+            config.setTestingEnabled(false);
+            sender.sendMessage(new TextComponent(ChatColor.GREEN + "Modo de pruebas desactivado."));
+        } else if (args[1].equalsIgnoreCase("start") && args.length >= 4) {
+            DayOfWeek day = DayOfWeek.valueOf(args[2].toUpperCase());
+            LocalTime time = LocalTime.parse(args[3]);
+            config.setTestSabbathStart(day, time);
+            sender.sendMessage(new TextComponent(ChatColor.GREEN + "Horario de inicio actualizado."));
+        } else if (args[1].equalsIgnoreCase("end") && args.length >= 4) {
+            DayOfWeek day = DayOfWeek.valueOf(args[2].toUpperCase());
+            LocalTime time = LocalTime.parse(args[3]);
+            config.setTestSabbathEnd(day, time);
+            sender.sendMessage(new TextComponent(ChatColor.GREEN + "Horario de fin actualizado."));
+        } else {
+            sendHelp(sender);
+        }
+    }
+
+    private void sendHelp(CommandSender sender) {
+        sender.sendMessage(new TextComponent(ChatColor.AQUA + "Comandos SabbathMode:"));
+        sender.sendMessage(new TextComponent(ChatColor.AQUA + "/sabbath reload"));
+        sender.sendMessage(new TextComponent(ChatColor.AQUA + "/sabbath whitelist add <jugador>"));
+        sender.sendMessage(new TextComponent(ChatColor.AQUA + "/sabbath whitelist remove <jugador>"));
+        sender.sendMessage(new TextComponent(ChatColor.AQUA + "/sabbath message show"));
+        sender.sendMessage(new TextComponent(ChatColor.AQUA + "/sabbath message set <mensaje>"));
+        sender.sendMessage(new TextComponent(ChatColor.AQUA + "/sabbath testing on|off"));
+        sender.sendMessage(new TextComponent(ChatColor.AQUA + "/sabbath testing start <DIA> <HH:mm>"));
+        sender.sendMessage(new TextComponent(ChatColor.AQUA + "/sabbath testing end <DIA> <HH:mm>"));
+    }
+}

--- a/src/main/java/studio/joaosouza/sabbathMode/config/PluginConfig.java
+++ b/src/main/java/studio/joaosouza/sabbathMode/config/PluginConfig.java
@@ -139,4 +139,60 @@ public class PluginConfig {
     public java.util.Set<String> getWhitelistedPlayers() {
         return whitelistedPlayers;
     }
+
+    // --- Métodos de actualización y guardado ---
+
+    public void reloadConfig() {
+        loadConfig();
+    }
+
+    public void saveConfig() {
+        try {
+            ConfigurationProvider.getProvider(YamlConfiguration.class).save(config, configFile);
+        } catch (Exception ex) {
+            plugin.getLogger().severe("Error al guardar la configuración: " + ex.getMessage());
+        }
+    }
+
+    public void addWhitelistedPlayer(String player) {
+        if (whitelistedPlayers.add(player.toLowerCase())) {
+            config.set("whitelist", new java.util.ArrayList<>(whitelistedPlayers));
+            saveConfig();
+        }
+    }
+
+    public void removeWhitelistedPlayer(String player) {
+        if (whitelistedPlayers.remove(player.toLowerCase())) {
+            config.set("whitelist", new java.util.ArrayList<>(whitelistedPlayers));
+            saveConfig();
+        }
+    }
+
+    public void setSabbathDeniedMessage(String message) {
+        this.sabbathDeniedMessage = message;
+        config.set("messages.sabbath-denied", message);
+        saveConfig();
+    }
+
+    public void setTestingEnabled(boolean enabled) {
+        this.testingEnabled = enabled;
+        config.set("testing.enabled", enabled);
+        saveConfig();
+    }
+
+    public void setTestSabbathStart(DayOfWeek day, LocalTime time) {
+        this.testSabbathStartDay = day;
+        this.testSabbathStartTime = time;
+        config.set("testing.sabbath-start-day", day.name());
+        config.set("testing.sabbath-start-time", time.format(java.time.format.DateTimeFormatter.ofPattern("HH:mm")));
+        saveConfig();
+    }
+
+    public void setTestSabbathEnd(DayOfWeek day, LocalTime time) {
+        this.testSabbathEndDay = day;
+        this.testSabbathEndTime = time;
+        config.set("testing.sabbath-end-day", day.name());
+        config.set("testing.sabbath-end-time", time.format(java.time.format.DateTimeFormatter.ofPattern("HH:mm")));
+        saveConfig();
+    }
 }

--- a/src/main/resources/bungee.yml
+++ b/src/main/resources/bungee.yml
@@ -3,3 +3,7 @@ version: ${project.version}
 main: studio.joaosouza.sabbathMode.SabbathMode
 author: ImJoaoSouza
 description: Restringe el acceso al servidor durante el Sabbath basado en la zona horaria del jugador.
+commands:
+  sabbath:
+    description: Comandos de administración de SabbathMode
+    permission: sabbathmode.admin


### PR DESCRIPTION
## Summary
- add `/sabbath` command for administration
- allow editing config values at runtime
- register the command in plugin.yml
- document new command usage

## Testing
- `mvn package` *(fails: Could not transfer artifact maven-resources-plugin: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6853c6a0635c83288142c0556aaa2bbb